### PR TITLE
Resolve #7: use access transformer to get the age of EntityItem.

### DIFF
--- a/src/main/java/info/u_team/useful_railroads/item/ItemBlockRailTeleport.java
+++ b/src/main/java/info/u_team/useful_railroads/item/ItemBlockRailTeleport.java
@@ -45,7 +45,7 @@ public class ItemBlockRailTeleport extends ItemBlock {
 				return false;
 			}
 			AxisAlignedBB aabb = new AxisAlignedBB(entityitem.posX - 1, entityitem.posY - 1, entityitem.posZ - 1, entityitem.posX + 1, entityitem.posY + 1, entityitem.posZ + 1);
-			world.getEntitiesWithinAABBExcludingEntity(entityitem, aabb).stream().filter(entity -> entity instanceof EntityItem).map(entity -> (EntityItem) entity).filter(entity -> entity.getAge() >= 100).forEach(entity -> {
+			world.getEntitiesWithinAABBExcludingEntity(entityitem, aabb).stream().filter(entity -> entity instanceof EntityItem).map(entity -> (EntityItem) entity).filter(entity -> entity.age >= 100).forEach(entity -> {
 				ItemStack stack = entity.getItem();
 				if (!stack.isEmpty()) {
 					Item item = stack.getItem();

--- a/src/main/java/info/u_team/useful_railroads/item/ItemBlockRailTeleport.java
+++ b/src/main/java/info/u_team/useful_railroads/item/ItemBlockRailTeleport.java
@@ -41,7 +41,7 @@ public class ItemBlockRailTeleport extends ItemBlock {
 				}
 			}
 		} else {
-			if (entityitem.getAge() < 100) {
+			if (entityitem.age < 100) {
 				return false;
 			}
 			AxisAlignedBB aabb = new AxisAlignedBB(entityitem.posX - 1, entityitem.posY - 1, entityitem.posZ - 1, entityitem.posX + 1, entityitem.posY + 1, entityitem.posZ + 1);

--- a/src/main/resources/usefulrailroads_at.cfg
+++ b/src/main/resources/usefulrailroads_at.cfg
@@ -14,3 +14,5 @@ protected net.minecraft.block.BlockRailBase$Rail func_180363_c(Lnet/minecraft/ut
 public net.minecraft.block.BlockRailBase$Rail func_150649_b(Lnet/minecraft/block/BlockRailBase$Rail;)Z # canConnectTo
 public net.minecraft.block.BlockRailBase$Rail func_150645_c(Lnet/minecraft/block/BlockRailBase$Rail;)V # connectTo
 protected net.minecraft.block.BlockRailBase$Rail func_180361_d(Lnet/minecraft/util/math/BlockPos;)Z # hasNeighborRail
+
+public net.minecraft.entity.item.EntityItem field_70292_b # age


### PR DESCRIPTION
Otherwise it violates the siding, as the `getAge` accessor it annotated
as being client-side only. As this value updates on both the server and
client sides, I'm not entirely sure what the reasoning was on it.

Regardless, this prevents the teleport rail from crashing in a
multiplayer server.