### PR TITLE
Refactor CustomPoweredRailBlock to allow more consistent speed setting

### DIFF
--- a/src/main/java/info/u_team/useful_railroads/block/CustomPoweredRailBlock.java
+++ b/src/main/java/info/u_team/useful_railroads/block/CustomPoweredRailBlock.java
@@ -80,7 +80,7 @@ public abstract class CustomPoweredRailBlock extends PoweredRailBlock implements
 			final double cartDistance = getPlaneSqrtDistance(cartMotion);
 			if (cartDistance > 0.01D) {
 				cart.setMotion(cartMotion.add(cartMotion.x / cartDistance * 0.06D, 0.0D, cartMotion.z / cartDistance * 0.06D));
-				controllSpeed(pos, state, cart);
+				controlSpeed(pos, state, cart);
 			} else {
 				double xCartMotion = cartMotion.x;
 				double zCartMotion = cartMotion.z;
@@ -106,7 +106,7 @@ public abstract class CustomPoweredRailBlock extends PoweredRailBlock implements
 		}
 	}
 	
-	protected void controllSpeed(BlockPos pos, BlockState state, AbstractMinecartEntity cart) {
+	protected void controlSpeed(BlockPos pos, BlockState state, AbstractMinecartEntity cart) {
 	}
 	
 	protected void speedUpCart(AbstractMinecartEntity cart, double speedMultiplier, double speedClamp) {

--- a/src/main/java/info/u_team/useful_railroads/block/CustomPoweredRailBlock.java
+++ b/src/main/java/info/u_team/useful_railroads/block/CustomPoweredRailBlock.java
@@ -44,74 +44,103 @@ public abstract class CustomPoweredRailBlock extends PoweredRailBlock implements
 	}
 	
 	protected void moveAlongTrack(BlockPos pos, BlockState state, AbstractMinecartEntity cart) {
-		boolean powered = false;
-		boolean notPoweredMovement = false;
-		
 		final AbstractRailBlock railBlock = (AbstractRailBlock) state.getBlock();
-		final RailShape shape = railBlock.getRailDirection(state, cart.world, pos, cart);
-		
-		if (railBlock == this) {
-			powered = state.get(PoweredRailBlock.POWERED);
-			notPoweredMovement = !powered;
+		final RailShape railDirection = railBlock.getRailDirection(state, cart.world, pos, cart);
+
+		boolean powered = (railBlock == this) ? state.get(PoweredRailBlock.POWERED) : false;
+
+		final double cartDistanceSqr = getPlaneSqrDistance(cart.getMotion());
+		if (cartDistanceSqr < 0.01D) {
+			doPassengerPush(cart);
+			return;
 		}
-		
+		if (cart.shouldDoRailFunctions()) {
+			if (powered) {
+				doPoweredMovement(pos, state, cart, railDirection);
+			} else {
+				doUnpoweredMovement(cart);
+			}
+		}
+	}
+
+	protected void doPassengerPush(AbstractMinecartEntity cart) {
 		final Entity passenger = cart.getPassengers().isEmpty() ? null : cart.getPassengers().get(0);
 		if (passenger instanceof PlayerEntity) {
 			final Vec3d passengerMotion = passenger.getMotion();
 			final double passengerDistanceSqr = getPlaneSqrDistance(passengerMotion);
-			final double cartDistanceSqr = getPlaneSqrDistance(cart.getMotion());
-			if (passengerDistanceSqr > 1.0E-4D && cartDistanceSqr < 0.01D) {
+
+			if (passengerDistanceSqr > 1.0E-4D) {
 				cart.setMotion(cart.getMotion().add(passengerMotion.x * 0.1D, 0.0D, passengerMotion.z * 0.1D));
-				notPoweredMovement = false;
-			}
-		}
-		
-		if (notPoweredMovement && cart.shouldDoRailFunctions()) {
-			final double cartDistance = getPlaneSqrtDistance(cart.getMotion());
-			if (cartDistance < 0.03D) {
-				cart.setMotion(Vec3d.ZERO);
-			} else {
-				cart.setMotion(cart.getMotion().mul(0.5D, 0.0D, 0.5D));
-			}
-		}
-		
-		if (powered && cart.shouldDoRailFunctions()) {
-			final Vec3d cartMotion = cart.getMotion();
-			final double cartDistance = getPlaneSqrtDistance(cartMotion);
-			if (cartDistance > 0.01D) {
-				cart.setMotion(cartMotion.add(cartMotion.x / cartDistance * 0.06D, 0.0D, cartMotion.z / cartDistance * 0.06D));
-				controlSpeed(pos, state, cart);
-			} else {
-				double xCartMotion = cartMotion.x;
-				double zCartMotion = cartMotion.z;
-				if (shape == RailShape.EAST_WEST) {
-					if (isNormalCube(cart.world, pos.west())) {
-						xCartMotion = 0.02D;
-					} else if (isNormalCube(cart.world, pos.east())) {
-						xCartMotion = -0.02D;
-					}
-				} else {
-					if (shape != RailShape.NORTH_SOUTH) {
-						return;
-					}
-					
-					if (isNormalCube(cart.world, pos.north())) {
-						zCartMotion = 0.02D;
-					} else if (isNormalCube(cart.world, pos.south())) {
-						zCartMotion = -0.02D;
-					}
-				}
-				cart.setMotion(xCartMotion, cartMotion.y, zCartMotion);
 			}
 		}
 	}
-	
+
+	protected void doUnpoweredMovement(AbstractMinecartEntity cart) {
+		final double cartDistance = getPlaneSqrtDistance(cart.getMotion());
+		if (cartDistance < 0.03D) {
+			cart.setMotion(Vec3d.ZERO);
+		} else {
+			cart.setMotion(cart.getMotion().mul(0.5D, 0.0D, 0.5D));
+		}
+	}
+
+	protected void doPoweredMovement(BlockPos pos, BlockState state, AbstractMinecartEntity cart, RailShape railDirection) {
+		final Vec3d cartMotion = cart.getMotion();
+		final double cartDistance = getPlaneSqrtDistance(cartMotion);
+		if (cartDistance > 0.01D) {
+			controlSpeed(pos, state, cart);
+		} else {
+			doPushOffWall(pos, cart, railDirection, cartMotion);
+		}
+	}
+
+	protected void doPushOffWall(BlockPos pos, AbstractMinecartEntity cart, RailShape railDirection, Vec3d cartMotion) {
+		double xCartMotion = cartMotion.x;
+		double zCartMotion = cartMotion.z;
+		if (railDirection == RailShape.EAST_WEST) {
+			if (isNormalCube(cart.world, pos.west())) {
+				xCartMotion = 0.02D;
+			} else if (isNormalCube(cart.world, pos.east())) {
+				xCartMotion = -0.02D;
+			}
+		} else if (railDirection == RailShape.NORTH_SOUTH) {
+			if (isNormalCube(cart.world, pos.north())) {
+				zCartMotion = 0.02D;
+			} else if (isNormalCube(cart.world, pos.south())) {
+				zCartMotion = -0.02D;
+			}
+		} else {
+			return;
+		}
+		cart.setMotion(xCartMotion, cartMotion.y, zCartMotion);
+	}
+
 	protected void controlSpeed(BlockPos pos, BlockState state, AbstractMinecartEntity cart) {
+		final Vec3d cartMotion = cart.getMotion();
+		final double cartDistance = getPlaneSqrtDistance(cartMotion);
+		cart.setMotion(cartMotion.add(cartMotion.x / cartDistance * 0.06D, 0.0D, cartMotion.z / cartDistance * 0.06D));
 	}
 	
 	protected void speedUpCart(AbstractMinecartEntity cart, double speedMultiplier, double speedClamp) {
 		final Vec3d motion = cart.getMotion();
+		// set motion manually before calling move to override some vanilla behaviour
+		cart.setMotion(new Vec3d(MathHelper.clamp(speedMultiplier * motion.x, -speedClamp, speedClamp), 0.0D, MathHelper.clamp(speedMultiplier * motion.z, -speedClamp, speedClamp)));
 		cart.move(MoverType.SELF, new Vec3d(MathHelper.clamp(speedMultiplier * motion.x, -speedClamp, speedClamp), 0.0D, MathHelper.clamp(speedMultiplier * motion.z, -speedClamp, speedClamp)));
+	}
+
+	protected void setCartSpeed(AbstractMinecartEntity cart, double speed) {
+		final Vec3d direction = cart.getMotion().normalize();
+		// set motion manually before calling move to override some vanilla behaviour
+		cart.setMotion(
+				direction.getX() * speed,
+				direction.getY() * speed,
+				direction.getZ() * speed
+		);
+		cart.move(MoverType.SELF, new Vec3d(
+				direction.getX() * speed,
+				direction.getY() * speed,
+				direction.getZ() * speed
+		));
 	}
 	
 	private static boolean isNormalCube(World world, BlockPos pos) {

--- a/src/main/java/info/u_team/useful_railroads/block/HighSpeedRailBlock.java
+++ b/src/main/java/info/u_team/useful_railroads/block/HighSpeedRailBlock.java
@@ -13,7 +13,7 @@ public class HighSpeedRailBlock extends CustomPoweredRailBlock {
 	}
 	
 	@Override
-	protected void controllSpeed(BlockPos pos, BlockState state, AbstractMinecartEntity cart) {
+	protected void controlSpeed(BlockPos pos, BlockState state, AbstractMinecartEntity cart) {
 		final double speedClamp = UsefulRailroadsConfig.HIGH_SPEED_RAIL_MAX_SPEED.get();
 		final double accelOcc = UsefulRailroadsConfig.HIGH_SPEED_RAIL_ACCEL_OCCUPIED.get();
 		final double accelUnocc = UsefulRailroadsConfig.HIGH_SPEED_RAIL_ACCEL_UNOCCUPIED.get();

--- a/src/main/java/info/u_team/useful_railroads/block/SpeedClampRailBlock.java
+++ b/src/main/java/info/u_team/useful_railroads/block/SpeedClampRailBlock.java
@@ -2,6 +2,7 @@ package info.u_team.useful_railroads.block;
 
 import info.u_team.useful_railroads.config.UsefulRailroadsConfig;
 import net.minecraft.block.BlockState;
+import net.minecraft.entity.MoverType;
 import net.minecraft.entity.item.minecart.AbstractMinecartEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
@@ -15,23 +16,7 @@ public class SpeedClampRailBlock extends CustomPoweredRailBlock {
 
 	@Override
 	protected void controlSpeed(BlockPos pos, BlockState state, AbstractMinecartEntity cart) {
-		final double clampVelocity = UsefulRailroadsConfig.SPEED_CLAMP_RAIL_SPEED.get();
-		final double currentVelocity = cart.getMotion().length();
-
-		Vec3d direction = Vec3d.ZERO;
-		if (currentVelocity < 0.1D) {
-			if (cart.getPassengers().size() > 0) {
-				direction = cart.getPassengers().get(0).getMotion().normalize();
-			}
-		} else {
-			direction = cart.getMotion().normalize();
-		}
-
-		cart.setMotion(new Vec3d(
-			direction.getX() * clampVelocity,
-			direction.getY() * clampVelocity,
-			direction.getZ() * clampVelocity
-		));
+		setCartSpeed(cart, UsefulRailroadsConfig.SPEED_CLAMP_RAIL_SPEED.get());
 	}
 
 	@Override

--- a/src/main/java/info/u_team/useful_railroads/block/SpeedClampRailBlock.java
+++ b/src/main/java/info/u_team/useful_railroads/block/SpeedClampRailBlock.java
@@ -14,7 +14,7 @@ public class SpeedClampRailBlock extends CustomPoweredRailBlock {
 	}
 
 	@Override
-	protected void controllSpeed(BlockPos pos, BlockState state, AbstractMinecartEntity cart) {
+	protected void controlSpeed(BlockPos pos, BlockState state, AbstractMinecartEntity cart) {
 		final double clampVelocity = UsefulRailroadsConfig.SPEED_CLAMP_RAIL_SPEED.get();
 		final double currentVelocity = cart.getMotion().length();
 


### PR DESCRIPTION
As per the issue #15 I found that setMotion() and move() both had limitations if one was set too differently to the other.

Refactored CustomPoweredRailBlock to allow easier setting of speeds and consistency for subclasses.

Also did some refactoring to allow easier overriding of specific functionality rather than have everything in one large function.

Updated SpeedClampRailBlock to use new setCartSpeed() method.

Tested with all mod's blocks other than the teleport rail (couldn't get the spawning of the target to work; not sure if I did it wrong as I've never used this rail).