### PR TITLE
Fixspeeds2

### DIFF
--- a/src/main/java/info/u_team/useful_railroads/block/CustomPoweredRailBlock.java
+++ b/src/main/java/info/u_team/useful_railroads/block/CustomPoweredRailBlock.java
@@ -96,15 +96,15 @@ public abstract class CustomPoweredRailBlock extends PoweredRailBlock implements
 		double zCartMotion = cartMotion.z;
 		if (railDirection == RailShape.EAST_WEST) {
 			if (isNormalCube(cart.world, pos.west())) {
-				xCartMotion = 0.02D;
+				xCartMotion = this.minSpeed;
 			} else if (isNormalCube(cart.world, pos.east())) {
-				xCartMotion = -0.02D;
+				xCartMotion = -this.minSpeed;
 			}
 		} else if (railDirection == RailShape.NORTH_SOUTH) {
 			if (isNormalCube(cart.world, pos.north())) {
-				zCartMotion = 0.02D;
+				zCartMotion = this.minSpeed;
 			} else if (isNormalCube(cart.world, pos.south())) {
-				zCartMotion = -0.02D;
+				zCartMotion = -this.minSpeed;
 			}
 		} else {
 			return;

--- a/src/main/java/info/u_team/useful_railroads/config/UsefulRailroadsConfig.java
+++ b/src/main/java/info/u_team/useful_railroads/config/UsefulRailroadsConfig.java
@@ -38,13 +38,13 @@ public class UsefulRailroadsConfig {
 		COMMON_BUILDER.comment("High Speed Rail Settings").push(SUBCATEGORY_RAIL_HIGHSPEED);
 
 		HIGH_SPEED_RAIL_MAX_SPEED = COMMON_BUILDER
-				.comment("Maximum Speed for High Speed Rail (default: 5.0)")
+				.comment("Maximum Speed for High Speed Rail (default: 5.0 blocks/tick)")
 				.defineInRange("highSpeedRailMaxSpeed", 5.0D, 0.0D, 10.0D);
 		HIGH_SPEED_RAIL_ACCEL_OCCUPIED = COMMON_BUILDER
-				.comment("Acceleration for High Speed Rail if Occupied (default: 4.0)")
+				.comment("Acceleration for High Speed Rail if Occupied (default: 4.0 blocks/tick^2)")
 				.defineInRange("highSpeedRailAccelOccupied", 4.0D, 0.0D, 10.0D);
 		HIGH_SPEED_RAIL_ACCEL_UNOCCUPIED = COMMON_BUILDER
-				.comment("Acceleration for High Speed Rail if Unoccupied (default: 2.0)")
+				.comment("Acceleration for High Speed Rail if Unoccupied (default: 2.0 blocks/tick^2)")
 				.defineInRange("highSpeedRailAccelUnoccupied", 2.0D, 0.0D, 10.0D);
 
 		COMMON_BUILDER.pop();
@@ -53,7 +53,7 @@ public class UsefulRailroadsConfig {
 	private static void setupSpeedClampConfig() {
 		COMMON_BUILDER.comment("Speed Clamp Rail Settings").push(SUBCATEGORY_RAIL_SPEEDCLAMP);
 
-		SPEED_CLAMP_RAIL_SPEED = COMMON_BUILDER.comment("Speed for Speed Clamp Rail (default: 0.25)")
+		SPEED_CLAMP_RAIL_SPEED = COMMON_BUILDER.comment("Speed for Speed Clamp Rail (default: 0.25 blocks/tick)")
 				.defineInRange("speedClampRailSpeed", 0.25D, 0.0D, 10.0D);
 
 		COMMON_BUILDER.pop();


### PR DESCRIPTION
Further consolidated setCartSpeed() and speedUpCart(). In order to do this I had to change the speedUpCart logic a little, from multiplying by a value to adding it (though this is actually more how real-world acceleration works so should be fine).

Added overloaded versions of setCartSpeed() to allow for easier use by subclasses.

Noticed that our version of "doPushOffWall()" was never called (vanilla powered rails version still functioned so I missed it in testing). Re-ordered checking logic to rectify. This also had the benefit of cleaning up the doPoweredMovement() function.

Updated config file to include units in comments (not really necessary but will hopefully stress how fast these values actually are).